### PR TITLE
Build: Stop using the deprecated form of AM_INIT_AUTOMAKE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,8 @@
 
 AC_PREREQ(2.59)
 AC_INIT(pm_crmgen, 2.0)
-AM_INIT_AUTOMAKE(pm_crmgen, 2.0)
+dnl Older distros may need: AM_INIT_AUTOMAKE($PACKAGE_NAME, $PACKAGE_VERSION)
+AM_INIT_AUTOMAKE
 
 # Checks for programs.
 AC_PROG_LN_S


### PR DESCRIPTION
This deters the following warning.

```
$ cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.0 (Maipo)

$ autoconf --version
autoconf (GNU Autoconf) 2.69

$ ./autogen.sh
configure.ac:6: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
configure.ac:6: http://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
```
